### PR TITLE
Feat/whisper

### DIFF
--- a/llmax/__init__.py
+++ b/llmax/__init__.py
@@ -1,12 +1,14 @@
+"""Llmax modules."""
+
 from . import clients, messages, models, usage, utils
 from .clients import MultiAIClient
 from .usage import tokens
 
 __all__ = [
+    "MultiAIClient",
     "clients",
     "messages",
     "models",
-    "MultiAIClient",
     "tokens",
     "usage",
     "utils",

--- a/llmax/__main__.py
+++ b/llmax/__main__.py
@@ -82,7 +82,7 @@ def main(model: Model, question: str, file_path: str) -> None:
         logger.info(deployments[model].endpoint)
 
         with Path(file_path).open(mode="rb") as audio_file:
-            response = client.speech_to_text(file=audio_file, model=model)  # type: ignore
+            response = client.speech_to_text(file=audio_file, model=model)
 
 
 if __name__ == "__main__":

--- a/llmax/__main__.py
+++ b/llmax/__main__.py
@@ -1,8 +1,10 @@
+"""Main file to launch the module."""
+
 import argparse
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
-from openai import AzureOpenAI
 
 from llmax.clients import MultiAIClient
 from llmax.models import Deployment, Model
@@ -71,18 +73,16 @@ def main(model: Model, question: str, file_path: str) -> None:
         logger.info(deployments[model].endpoint)
 
         response = client.invoke_to_str(messages, model)
-        print(response)
 
         response = client.stream(messages, model)
-        for chunk in response:
-            print(chunk.choices[0].delta.content, end="")
+        for _chunk in response:
+            pass
     else:
         logger.info(f"STT with {model} model...")
         logger.info(deployments[model].endpoint)
 
-        with open(file_path, "rb") as audio_file:
-            response = client.speech_to_text(file=audio_file, model=model)
-            print(response)
+        with Path(file_path).open(mode="rb") as audio_file:
+            response = client.speech_to_text(file=audio_file, model=model)  # type: ignore
 
 
 if __name__ == "__main__":
@@ -94,10 +94,16 @@ if __name__ == "__main__":
         help="The model to speak with (e.g., 'gpt-4o', 'gpt-4-turbo', etc.)",
     )
     parser.add_argument(
-        "--question", type=str, required=False, help="The question to ask the model"
+        "--question",
+        type=str,
+        required=False,
+        help="The question to ask the model",
     )
     parser.add_argument(
-        "--file", type=str, required=False, help="The audio file to convert to text"
+        "--file",
+        type=str,
+        required=False,
+        help="The audio file to convert to text",
     )
 
     args = parser.parse_args()

--- a/llmax/__main__.py
+++ b/llmax/__main__.py
@@ -73,16 +73,18 @@ def main(model: Model, question: str, file_path: str) -> None:
         logger.info(deployments[model].endpoint)
 
         response = client.invoke_to_str(messages, model)
+        logger.info(response)
 
         response = client.stream(messages, model)
-        for _chunk in response:
-            pass
+        logger.info(response)
+
     else:
         logger.info(f"STT with {model} model...")
         logger.info(deployments[model].endpoint)
 
         with Path(file_path).open(mode="rb") as audio_file:
             response = client.speech_to_text(file=audio_file, model=model)
+            logger.info(response)
 
 
 if __name__ == "__main__":

--- a/llmax/clients/__init__.py
+++ b/llmax/clients/__init__.py
@@ -1,3 +1,5 @@
+"""The client object."""
+
 from .multi_ai_client import MultiAIClient
 
 __all__ = [

--- a/llmax/clients/multi_ai_client.py
+++ b/llmax/clients/multi_ai_client.py
@@ -8,6 +8,7 @@ from io import BufferedReader, BytesIO
 from typing import Any, Callable, Generator
 
 from openai.types import Embedding
+from openai.types.audio import Transcription
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from llmax.external_clients.clients import Client, get_aclient, get_client
@@ -326,8 +327,13 @@ class MultiAIClient:
         response = client.audio.transcriptions.create(
             file=file,
             model=deployment.deployment_name,
+            response_format="verbose_json",
             **kwargs,
         )
+
+        usage = ModelUsage(deployment, self._increment_usage)
+        usage.add_audio_duration(response.duration)
+        usage.apply()
 
         return response
 
@@ -336,7 +342,7 @@ class MultiAIClient:
         file: BytesIO,
         model: Model,
         **kwargs: Any,
-    ) -> str:
+    ) -> Transcription:
         """Asynchronously processes audio data for speech-to-text using the Whisper model.
 
         Args:
@@ -353,11 +359,12 @@ class MultiAIClient:
         response = await aclient.audio.transcriptions.create(
             file=file,
             model=deployment.deployment_name,
+            response_format="verbose_json",
             **kwargs,
         )
 
-        """usage = ModelUsage(deployment, self._increment_usage)
-        usage.add_audio_duration(self.calculate_duration(audio_file=file))
-        usage.apply()"""
+        usage = ModelUsage(deployment, self._increment_usage)
+        usage.add_audio_duration(response.duration)
+        usage.apply()
 
         return response

--- a/llmax/clients/multi_ai_client.py
+++ b/llmax/clients/multi_ai_client.py
@@ -4,6 +4,7 @@ This class is used to interface with multiple LLMs and AI models, supporting bot
 synchronous and asynchronous operations.
 """
 
+from io import BytesIO
 from typing import Any, Callable, Generator
 
 from openai.types import Embedding
@@ -87,6 +88,7 @@ class MultiAIClient:
         Args:
             messages: The list of messages to process.
             model: The model to use for generating completions.
+            kwargs: More args.
 
         Returns:
             ChatCompletion: The completion response from the API.
@@ -111,6 +113,7 @@ class MultiAIClient:
         Args:
             messages: The list of messages to process.
             model: The model to use for generating completions.
+            kwargs: More args.
 
         Returns:
             ChatCompletion: The completion response from the API.
@@ -134,12 +137,15 @@ class MultiAIClient:
         Args:
             messages: The list of messages for the chat.
             model: The model to use for generating the chat completions.
+            kwargs: More args.
 
         Returns:
             ChatCompletion: The API response containing the chat completions.
         """
         response = self._create_chat(messages, model, **kwargs, stream=False)
-        assert response.usage, "No usage for this request"
+        if not response.usage:
+            message = "No usage for this request"
+            raise ValueError(message)
         deployment = self.deployments[model]
         usage = ModelUsage(deployment, self._increment_usage, response.usage)
         usage.apply()
@@ -156,6 +162,7 @@ class MultiAIClient:
         Args:
             messages: The list of messages for the chat.
             model: The model to use for the chat completions.
+            kwargs: More args.
 
         Returns:
             str | None: The content of the first choice in the response, if available.
@@ -174,12 +181,15 @@ class MultiAIClient:
         Args:
             messages: The list of messages for the chat.
             model: The model to use for generating the chat completions.
+            kwargs: More args.
 
         Returns:
             ChatCompletion: The API response containing the chat completions.
         """
         response = await self._acreate_chat(messages, model, **kwargs, stream=False)
-        assert response.usage, "No usage for this request"
+        if not response.usage:
+            message = "No usage for this request"
+            raise ValueError(message)
         deployment = self.deployments[model]
         usage = ModelUsage(deployment, self._increment_usage, response.usage)
         usage.apply()
@@ -196,6 +206,7 @@ class MultiAIClient:
         Args:
             messages: The list of messages for the chat.
             model: The model to use for the chat completions.
+            kwargs: More args.
 
         Returns:
             str | None: The content of the first choice in the response, if available.
@@ -214,6 +225,7 @@ class MultiAIClient:
         Args:
             messages: The list of messages for the chat.
             model: The model to use for generating the chat completions.
+            kwargs: More args.
 
         Yields:
             ChatCompletionChunk: Individual chunks of the completion response.
@@ -225,7 +237,7 @@ class MultiAIClient:
 
         for chunk in response:
             usage.add_tokens(completion_tokens=1)
-            yield chunk
+            yield chunk  # type: ignore
 
         usage.apply()
 
@@ -243,6 +255,7 @@ class MultiAIClient:
         Args:
             messages: The list of messages for the chat.
             model: The model to use for generating the chat completions.
+            kwargs: More args.
 
         Yields:
             str: Formatted output for each chunk.
@@ -293,14 +306,14 @@ class MultiAIClient:
 
     def speech_to_text(
         self,
-        file,
+        file: BytesIO,
         model: Model,
         **kwargs: Any,
     ) -> str:
         """Synchronously processes audio data for speech-to-text using the Whisper model.
 
         Args:
-            audio_data: The audio data to process.
+            file: The audio data to process.
             model: The model to use for processing the audio.
             kwargs: Additional arguments to pass to the API.
 
@@ -316,22 +329,18 @@ class MultiAIClient:
             **kwargs,
         )
 
-        # usage = ModelUsage(deployment, self._increment_usage)
-        # usage.add_audio_duration(len(file) / 1_000)
-        # usage.apply()
-
         return response
 
     async def aspeech_to_text(
         self,
-        file,
+        file: BytesIO,
         model: Model,
         **kwargs: Any,
     ) -> str:
         """Asynchronously processes audio data for speech-to-text using the Whisper model.
 
         Args:
-            audio_data: The audio data to process.
+            file: The audio data to process.
             model: The model to use for processing the audio.
             kwargs: Additional arguments to pass to the API.
 
@@ -346,9 +355,5 @@ class MultiAIClient:
             model=deployment.deployment_name,
             **kwargs,
         )
-
-        # usage = ModelUsage(deployment, self._increment_usage)
-        # usage.add_audio_duration(len(file) / 1_000)
-        # usage.apply()
 
         return response

--- a/llmax/clients/multi_ai_client.py
+++ b/llmax/clients/multi_ai_client.py
@@ -4,7 +4,7 @@ This class is used to interface with multiple LLMs and AI models, supporting bot
 synchronous and asynchronous operations.
 """
 
-from io import BytesIO
+from io import BufferedReader, BytesIO
 from typing import Any, Callable, Generator
 
 from openai.types import Embedding
@@ -306,7 +306,7 @@ class MultiAIClient:
 
     def speech_to_text(
         self,
-        file: BytesIO,
+        file: BufferedReader,
         model: Model,
         **kwargs: Any,
     ) -> str:
@@ -355,5 +355,9 @@ class MultiAIClient:
             model=deployment.deployment_name,
             **kwargs,
         )
+
+        """usage = ModelUsage(deployment, self._increment_usage)
+        usage.add_audio_duration(self.calculate_duration(audio_file=file))
+        usage.apply()"""
 
         return response

--- a/llmax/external_clients/__init__.py
+++ b/llmax/external_clients/__init__.py
@@ -1,3 +1,5 @@
+"""Clients, with async and sync."""
+
 from .clients import get_aclient, get_client
 
 __all__ = [

--- a/llmax/external_clients/whisper.py
+++ b/llmax/external_clients/whisper.py
@@ -1,0 +1,1 @@
+"""Whisper client."""

--- a/llmax/messages/__init__.py
+++ b/llmax/messages/__init__.py
@@ -1,3 +1,5 @@
+"""Message and Messages types."""
+
 from .message import Message
 from .messages import Messages
 

--- a/llmax/messages/message.py
+++ b/llmax/messages/message.py
@@ -1,3 +1,5 @@
+"""Message type."""
+
 from typing import Any
 
 Message = Any

--- a/llmax/messages/messages.py
+++ b/llmax/messages/messages.py
@@ -1,3 +1,5 @@
+"""Messages type."""
+
 from .message import Message
 
 Messages = list[Message]

--- a/llmax/models/__init__.py
+++ b/llmax/models/__init__.py
@@ -7,13 +7,13 @@ from .providers import PROVIDERS, Provider
 
 __all__ = [
     "COHERE_MODELS",
-    "Deployment",
-    "Deployment",
-    "fake_llm",
     "MISTRAL_MODELS",
-    "Model",
     "MODELS",
     "OPENAI_MODELS",
-    "Provider",
     "PROVIDERS",
+    "Deployment",
+    "Deployment",
+    "Model",
+    "Provider",
+    "fake_llm",
 ]

--- a/llmax/usage/__init__.py
+++ b/llmax/usage/__init__.py
@@ -1,3 +1,5 @@
+"""Usage package."""
+
 from .usage import ModelUsage
 
 __all__ = ["ModelUsage"]

--- a/llmax/usage/usage.py
+++ b/llmax/usage/usage.py
@@ -120,6 +120,6 @@ class ModelUsage:
                 f"Cost: ${self.compute_cost():.6f}"
             )
         logger.debug(
-            f"[bold purple]LLMAX[/bold purple]Applying usage for model '{self.deployment.model}'. {message}",
+            f"[bold purple][LLMAX][/bold purple] Applying usage for model '{self.deployment.model}'. {message}",
         )
         self.increment_usage(self.compute_cost(), self.deployment.model)

--- a/llmax/usage/usage.py
+++ b/llmax/usage/usage.py
@@ -119,5 +119,7 @@ class ModelUsage:
                 f"({self.tokens_usage.prompt_tokens} + {self.tokens_usage.completion_tokens}) "
                 f"Cost: ${self.compute_cost():.6f}"
             )
-        logger.debug(f"Applying usage for model '{self.deployment.model}'. {message}")
+        logger.debug(
+            f"[bold purple]LLMAX[/bold purple]Applying usage for model '{self.deployment.model}'. {message}",
+        )
         self.increment_usage(self.compute_cost(), self.deployment.model)

--- a/llmax/utils/__init__.py
+++ b/llmax/utils/__init__.py
@@ -1,3 +1,5 @@
+"""Package with the logger."""
+
 from .logger import logger
 
 __all__ = ["logger"]

--- a/llmax/utils/logger.py
+++ b/llmax/utils/logger.py
@@ -1,3 +1,5 @@
+"""Logger module."""
+
 import sys
 
 from loguru import logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ ignore = [
   "FBT002", # bool arguments
   "ANN401", # Any for kwargs
   "CPY001", #copyright
-  "B901", # yield and return in generator
+
   "S311" , # usage of rnadom
   "PGH003", #type ignore
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,13 @@ ignore = [
   "ANN101",
   "RET504", # unnecessary-allign
   "E501",   # line too long
+  "FBT001", # bool arguments
+  "FBT002", # bool arguments
+  "ANN401", # Any for kwargs
+  "CPY001", #copyright
+  "B901", # yield and return in generator
+  "S311" , # usage of rnadom
+  "PGH003", #type ignore
 ]
 
 pydocstyle.convention = "google"


### PR DESCRIPTION
En utilisant le paramètre `verbose_json`, on peut récupérer la durée de l'audio traité.
Attention, car ce paramètre était aussi passé dans recap, donc il faudra faire la modification dans `utils/transcript.py` de :
```bash
chunk_transcription = await client.aspeech_to_text(
                    file=chunk,
                    model=settings.app.recap.whisper.MODEL,
                    temperature=settings.app.recap.whisper.TEMPERATURE,
                    language=language,
                    prompt=prompt,
                    response_format="verbose_json",
                    timestamp_granularities=["segment"],
                )
```
à
```bash
chunk_transcription = await client.aspeech_to_text(
                    file=chunk,
                    model=settings.app.recap.whisper.MODEL,
                    temperature=settings.app.recap.whisper.TEMPERATURE,
                    language=language,
                    prompt=prompt,
                    timestamp_granularities=["segment"],
                )
```