### PR TITLE
Feat/message typehint

### DIFF
--- a/llmax/__main__.py
+++ b/llmax/__main__.py
@@ -73,16 +73,18 @@ def main(model: Model, question: str, file_path: str) -> None:
         logger.info(deployments[model].endpoint)
 
         response = client.invoke_to_str(messages, model)
+        logger.info(response)
 
         response = client.stream(messages, model)
-        for _chunk in response:
-            pass
+        logger.info(response)
+
     else:
         logger.info(f"STT with {model} model...")
         logger.info(deployments[model].endpoint)
 
         with Path(file_path).open(mode="rb") as audio_file:
             response = client.speech_to_text(file=audio_file, model=model)
+            logger.info(response)
 
 
 if __name__ == "__main__":

--- a/llmax/clients/multi_ai_client.py
+++ b/llmax/clients/multi_ai_client.py
@@ -8,6 +8,7 @@ from io import BufferedReader, BytesIO
 from typing import Any, Callable, Generator
 
 from openai.types import Embedding
+from openai.types.audio import Transcription
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from llmax.external_clients.clients import Client, get_aclient, get_client
@@ -326,8 +327,13 @@ class MultiAIClient:
         response = client.audio.transcriptions.create(
             file=file,
             model=deployment.deployment_name,
+            response_format="verbose_json",
             **kwargs,
         )
+
+        usage = ModelUsage(deployment, self._increment_usage)
+        usage.add_audio_duration(response.duration)
+        usage.apply()
 
         return response
 
@@ -336,7 +342,7 @@ class MultiAIClient:
         file: BytesIO,
         model: Model,
         **kwargs: Any,
-    ) -> str:
+    ) -> Transcription:
         """Asynchronously processes audio data for speech-to-text using the Whisper model.
 
         Args:
@@ -353,11 +359,12 @@ class MultiAIClient:
         response = await aclient.audio.transcriptions.create(
             file=file,
             model=deployment.deployment_name,
+            response_format="verbose_json",
             **kwargs,
         )
 
-        """usage = ModelUsage(deployment, self._increment_usage)
-        usage.add_audio_duration(self.calculate_duration(audio_file=file))
-        usage.apply()"""
+        usage = ModelUsage(deployment, self._increment_usage)
+        usage.add_audio_duration(response.duration)
+        usage.apply()
 
         return response

--- a/llmax/messages/message.py
+++ b/llmax/messages/message.py
@@ -1,5 +1,12 @@
 """Message type."""
 
-from typing import Any
+from typing import Any, Literal
 
-Message = Any
+from pydantic import BaseModel
+
+
+class Message(BaseModel):
+    """Message."""
+
+    role: Literal["user", "assistant", "system"]
+    content: Any


### PR DESCRIPTION
Si on fait ça, il faudra repasser dans cosmos sur environ 30 lignes pour mieux formatter les messages envoyés (pas trop long)

Sinon, toujours avec un repassage, on peut utiliser 
```
from openai.types.chat import ChatCompletionMessageParam
Message = ChatCompletionMessageParam 
```
qui provient d'openAI

A discuter, à  la demande de Pierre F