### PR TITLE
feat: add GLM 4.6/4.7, Llama 4 Maverick, Qwen 3.6 Plus via OpenRouter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "delos-llmax"
 
 
-version = "1.35.1"
+version = "1.36.0"
 description = "Interface to handle multiple LLMs and AI tools."
 authors = [
     { name = "Delos Intelligence", email = "maximiliendedinechin@delosintelligence.fr" },

--- a/src/llmax/models/models.py
+++ b/src/llmax/models/models.py
@@ -75,6 +75,10 @@ GrokModel = Literal["grok-4-1-fast"]
 OpenRouterModel = Literal[
     "deepseek-v4-pro",
     "deepseek-v4-flash",
+    "glm-4.7",
+    "glm-4.6",
+    "llama-4-maverick",
+    "qwen3.6-plus",
 ]
 
 ScalewayModel = Literal[

--- a/src/llmax/usage/prices.py
+++ b/src/llmax/usage/prices.py
@@ -58,6 +58,10 @@ PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "gemini-3.1-flash-lite-preview": 0.25,
     "deepseek-v4-pro": {"openrouter": 0.435},
     "deepseek-v4-flash": {"openrouter": 0.14},
+    "glm-4.6": {"openrouter": 0.39},
+    "glm-4.7": {"openrouter": 0.38},
+    "llama-4-maverick": {"openrouter": 0.15},
+    "qwen3.6-plus": {"openrouter": 0.325},
 }
 
 CACHED_PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
@@ -140,6 +144,10 @@ COMPLETION_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "gemini-3.1-flash-lite-preview": 1.5,
     "deepseek-v4-pro": {"openrouter": 0.87},
     "deepseek-v4-flash": {"openrouter": 0.28},
+    "glm-4.6": {"openrouter": 1.90},
+    "glm-4.7": {"openrouter": 1.74},
+    "llama-4-maverick": {"openrouter": 0.60},
+    "qwen3.6-plus": {"openrouter": 1.95},
 }
 
 TRANSCRIPTION_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {


### PR DESCRIPTION
Bumps version to 1.36.0.