### PR TITLE
fix: drop reasoning_effort kwarg for Anthropic models

### DIFF
--- a/src/llmax/clients/multi_ai_client.py
+++ b/src/llmax/clients/multi_ai_client.py
@@ -256,6 +256,7 @@ class MultiAIClient:
         if deployment.model in ANTHROPIC_MODELS:
             kwargs.pop("stream_options", None)
             kwargs.pop("response_format", None)
+            kwargs.pop("reasoning_effort", None)
             if "max_completion_tokens" in kwargs:
                 kwargs["max_tokens"] = kwargs.pop("max_completion_tokens")
 

--- a/src/llmax/models/models.py
+++ b/src/llmax/models/models.py
@@ -86,6 +86,7 @@ ScalewayModel = Literal[
     "holo2-30b-a3b",
     "qwen3-embedding-8b",
     "qwen3.6-35b-a3b",
+    "qwen3-coder-30b-a3b-instruct",
 ]
 
 ElevenLabsModel = Literal[

--- a/src/llmax/usage/prices.py
+++ b/src/llmax/usage/prices.py
@@ -51,6 +51,7 @@ PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "holo2-30b-a3b": {"scaleway": 0.345},  # €0.30 → $0.345
     "qwen3-embedding-8b": {"scaleway": 0.115},  # €0.10 → $0.115
     "qwen3.6-35b-a3b": {"scaleway": 0.2875, "openrouter": 0.14},
+    "qwen3-coder-30b-a3b-instruct": {"scaleway": 0.23},  # €0.20 → $0.23
     "gemini-3-pro-preview": 2,
     "deepseek-v4-pro": {"openrouter": 0.435},
     "deepseek-v4-flash": {"openrouter": 0.14},
@@ -129,6 +130,7 @@ COMPLETION_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "pixtral-12b-2409": {"scaleway": 0.23},  # €0.20 → $0.23
     "holo2-30b-a3b": {"scaleway": 0.805},  # €0.70 → $0.805
     "qwen3.6-35b-a3b": {"scaleway": 1.725, "openrouter": 1.00},
+    "qwen3-coder-30b-a3b-instruct": {"scaleway": 0.92},  # €0.80 → $0.92
     "gemini-3-pro-preview": 12,
     "deepseek-v4-pro": {"openrouter": 0.87},
     "deepseek-v4-flash": {"openrouter": 0.28},

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "delos-llmax"
-version = "1.42.0"
+version = "1.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
reasoning_effort is an OpenAI-style param; on fallback to an Anthropic model it leaked into client.messages.create() and raised TypeError. Strip it in clean_kwargs alongside response_format/stream_options.

Fixes COSMOS-BACKEND-18Q