### PR TITLE
feat(anthropic): let callers place their own system cache breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,33 @@ response = await client.ainvoke_to_str(
 When creating the client, you can also specify two functions, *increment_usage* and *get_usage*.
 The first one is **Callable[[float, Model], bool]** while the second is **Callable[[], float]**.
 *increment_usage* is a function that is called after a call of the llm. The float is the price and Model, the model used. It can therefore be used to update your database. *get_usage* returns whether a condition is met. For instance, it can be a function that calls your database and returns whether the user is still active.
+# Prompt caching Anthropic — breakpoints personnalisés
+
+Pour les modèles Anthropic, `llmax` pose automatiquement des breakpoints de cache
+(`cache_control: ephemeral`) : un sur le bloc system, un sur le dernier tool, et un
+sur chacun des deux derniers messages (le maximum de 4 autorisé par Anthropic).
+
+Par défaut, `system` est une **string** → elle devient un seul bloc avec un breakpoint
+à la fin. Comportement inchangé.
+
+Vous pouvez aussi passer `system` comme **liste de blocs de contenu** et placer vos
+propres breakpoints — utile pour isoler un préfixe stable, partagé entre utilisateurs
+(donc lu en cache cross-requêtes), d'une queue spécifique à l'utilisateur :
+
+```python
+client.stream(
+    messages,
+    model="claude-4.6-sonnet",
+    system=[
+        # Préfixe stable (rôle, outils, capacités) — partagé entre utilisateurs
+        {"type": "text", "text": prefixe_commun, "cache_control": {"type": "ephemeral"}},
+        # Queue spécifique à l'utilisateur (mémoire, contexte) — cache par utilisateur
+        {"type": "text", "text": contexte_utilisateur, "cache_control": {"type": "ephemeral"}},
+    ],
+)
+```
+
+Budget : Anthropic limite à **4 breakpoints**. Deux sont réservés aux deux derniers
+messages. Si le system en utilise 2, le breakpoint du tableau d'outils est
+automatiquement retiré (le premier breakpoint system, situé après les outils, les
+cache déjà). Au-delà de 2 breakpoints system, c'est au caller de rester sous la limite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "delos-llmax"
 
 
-version = "1.47.0"
+version = "1.48.0"
 description = "Interface to handle multiple LLMs and AI tools."
 authors = [
     { name = "Delos Intelligence", email = "maximiliendedinechin@delosintelligence.fr" },

--- a/src/llmax/clients/multi_ai_client.py
+++ b/src/llmax/clients/multi_ai_client.py
@@ -414,7 +414,7 @@ class MultiAIClient:
         self,
         messages: Messages,
         models: list[Model],
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         delay: float = 0.0,
         tries: int = 1,
         **kwargs: Any,
@@ -464,7 +464,7 @@ class MultiAIClient:
         self,
         messages: Messages,
         model: Model | list[Model],
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         delay: float = 0.0,
         tries: int = 1,
         **kwargs: Any,
@@ -501,7 +501,7 @@ class MultiAIClient:
         messages: Messages,
         models: list[Model],
         operation: str,
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         delay: float = 0.0,
         tries: int = 1,
         **kwargs: Any,
@@ -576,7 +576,7 @@ class MultiAIClient:
         messages: Messages,
         model: Model | list[Model],
         operation: str,
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         delay: float = 0.0,
         tries: int = 1,
         **kwargs: Any,
@@ -612,7 +612,7 @@ class MultiAIClient:
         messages: Messages,
         model: list[Model] | Model,
         operation: str,
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         delay: float = 0.0,
         tries: int = 1,
         **kwargs: Any,
@@ -651,7 +651,7 @@ class MultiAIClient:
         model: Model | list[Model],
         execute_tools: Callable[[str, str], Awaitable[str]],
         operation: str,
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         delay: float = 0.0,
         max_tool_calls: int = 4,
         tries: int = 1,
@@ -732,7 +732,7 @@ class MultiAIClient:
         self,
         messages: Messages,
         model: Model | list[Model],
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         **kwargs: Any,
     ) -> Generator[ChatCompletionChunk | CompletionUsage | Model, None, None]:
         """Streams chat completions, allowing responses to be received in chunks.
@@ -796,7 +796,7 @@ class MultiAIClient:
         model: list[Model] | Model,
         smooth_duration: int,
         operation: str,
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamedItem, None]:
         """Streams formatted output from the chat completions.
@@ -931,7 +931,7 @@ class MultiAIClient:
         messages: Messages,
         model: list[Model] | Model,
         operation: str,
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         smooth_duration: int | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[StreamedItem, None]:
@@ -966,7 +966,7 @@ class MultiAIClient:
         model: list[Model] | Model,
         operation: str,
         execute_tools: Callable[[str, str, str], AsyncGenerator[ToolItem, None]],
-        system: str | None = None,
+        system: str | list[dict[str, Any]] | None = None,
         smooth_duration: int | None = None,
         max_tool_calls: int = 4,
         max_tokens_before_tool_use: int | None = None,
@@ -2063,16 +2063,15 @@ def _extract_image_from_gemini_response(response: Any) -> bytes | None:
 
 def add_system_message(
     messages: Messages,
-    system: str,
+    system: str | list[dict[str, Any]],
 ) -> Messages:
     """Adds a system message at the start of the messages.
 
-    It should take into account the model name to correctly name the system.
-
     Args:
         messages: The list of messages for the chat.
-        model: The model to use for generating the chat completions.
-        system: A string that will be passed as a system prompt.
+        system: The system prompt — a plain string, or a list of content blocks
+            (e.g. Anthropic text blocks carrying their own ``cache_control``) when
+            the caller wants to position its own cache breakpoints.
 
     Returns:
         Messages: The same initial list with the system message inserted at index 0.

--- a/src/llmax/external_clients/anthropic.py
+++ b/src/llmax/external_clients/anthropic.py
@@ -34,34 +34,76 @@ MAPPING_FINISH_REASON: dict[str, str] = {
 
 DEFAULT_MAX_TOKENS = 10_000
 
+# Anthropic allows at most 4 cache_control breakpoints per request. Two are always
+# reserved for the last two messages (see ``_add_message_cache_control``); the
+# remaining two are shared between the system and the tools array. Once the system
+# uses both, the tools breakpoint is dropped — the first system breakpoint sits
+# after the tools array and already caches it.
+_MAX_NON_MESSAGE_BREAKPOINTS = 2
+
 
 def _extract_system(
     messages: Messages,
-) -> tuple[list[dict[str, Any]] | anthropic.NotGiven, Messages]:
-    """Separate system messages from the list, return (system_blocks, remaining).
+) -> tuple[list[dict[str, Any]] | anthropic.NotGiven, Messages, int]:
+    """Separate system messages from the list.
 
-    Returns system as a list with cache_control to enable prompt caching.
+    Returns ``(system_blocks, remaining, n_breakpoints)``.
+
+    Two modes:
+
+    - **Default** — every system message has plain-string content: they are
+      concatenated into a single text block with one trailing ``cache_control``
+      breakpoint. Byte-identical to the historical behaviour.
+    - **Manual** — a system message carries *list* content (pre-built Anthropic
+      text blocks): the blocks are preserved verbatim, honouring any
+      ``cache_control`` the caller placed on them. This lets a caller position
+      its own breakpoints — e.g. a stable, cross-user cohort prefix followed by
+      a per-user tail. If the caller supplied blocks but marked none, a trailing
+      ``cache_control`` is added so caching still applies (default-equivalent).
+
+    ``n_breakpoints`` is how many ``cache_control`` markers the system uses, so
+    the caller (``anthropic_create``/``acreate``) can keep the request within
+    Anthropic's 4-breakpoint budget — see ``_convert_tools(enable_cache=...)``.
     """
     system_parts: list[str] = []
+    manual_blocks: list[dict[str, Any]] = []
+    has_list_content = False
     remaining: Messages = []
     for msg in messages:
-        if msg.get("role") == "system":
-            content = msg.get("content", "")
-            if isinstance(content, str):
-                system_parts.append(content)
-            elif isinstance(content, list):
-                system_parts.append(" ".join(str(c) for c in content))
-        else:
+        if msg.get("role") != "system":
             remaining.append(msg)
-    if system_parts:
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            has_list_content = True
+            for block in content:
+                if isinstance(block, dict):
+                    manual_blocks.append(dict(block))
+                else:
+                    manual_blocks.append({"type": "text", "text": str(block)})
+        else:
+            system_parts.append(content)
+            manual_blocks.append({"type": "text", "text": content})
+
+    if not manual_blocks:
+        return anthropic.NOT_GIVEN, remaining, 0
+
+    if not has_list_content:
+        # Default mode — single concatenated block, one trailing breakpoint.
         return [
             {
                 "type": "text",
                 "text": " ".join(system_parts),
                 "cache_control": {"type": "ephemeral"},
             },
-        ], remaining
-    return anthropic.NOT_GIVEN, remaining
+        ], remaining, 1
+
+    # Manual mode — preserve caller blocks and the cache_control markers they set.
+    n_breakpoints = sum(1 for b in manual_blocks if b.get("cache_control"))
+    if n_breakpoints == 0:
+        manual_blocks[-1]["cache_control"] = {"type": "ephemeral"}
+        n_breakpoints = 1
+    return manual_blocks, remaining, n_breakpoints
 
 
 def _add_message_cache_control(messages: Messages) -> Messages:
@@ -108,8 +150,14 @@ def _add_message_cache_control(messages: Messages) -> Messages:
     return messages
 
 
-def _convert_tools(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Convert OpenAI-style tools to Anthropic format, mutating kwargs in place."""
+def _convert_tools(kwargs: dict[str, Any], *, enable_cache: bool = True) -> dict[str, Any]:
+    """Convert OpenAI-style tools to Anthropic format, mutating kwargs in place.
+
+    ``enable_cache`` adds a ``cache_control`` breakpoint on the last tool (default).
+    Set it ``False`` to drop that breakpoint — used when the system already places
+    a breakpoint *after* the tools array (which subsumes it), so the request stays
+    within Anthropic's 4-breakpoint budget.
+    """
     if "tools" in kwargs:
         tools = kwargs.pop("tools")
         if tools:
@@ -123,7 +171,8 @@ def _convert_tools(kwargs: dict[str, Any]) -> dict[str, Any]:
                 if tool.get("type") == "function"
             ]
             if anthropic_tools:
-                anthropic_tools[-1]["cache_control"] = {"type": "ephemeral"}
+                if enable_cache:
+                    anthropic_tools[-1]["cache_control"] = {"type": "ephemeral"}
                 kwargs["tools"] = anthropic_tools
 
     if "tool_choice" in kwargs:
@@ -561,9 +610,12 @@ def anthropic_create(
     **kwargs: Any,
 ) -> ChatCompletion | Generator[ChatCompletionChunk, None, None]:
     """Synchronous Anthropic call, returns ChatCompletion or streaming generator."""
-    system, remaining = _extract_system(messages)
+    system, remaining, n_sys_breakpoints = _extract_system(messages)
     remaining = _add_message_cache_control(remaining)
-    kwargs = _convert_tools(kwargs)
+    kwargs = _convert_tools(
+        kwargs,
+        enable_cache=(n_sys_breakpoints < _MAX_NON_MESSAGE_BREAKPOINTS),
+    )
     stream = kwargs.pop("stream", False)
 
     if "max_tokens" not in kwargs:
@@ -595,9 +647,12 @@ async def anthropic_acreate(
     **kwargs: Any,
 ) -> ChatCompletion | AsyncGenerator[ChatCompletionChunk, None]:
     """Async Anthropic call, returns ChatCompletion or async streaming generator."""
-    system, remaining = _extract_system(messages)
+    system, remaining, n_sys_breakpoints = _extract_system(messages)
     remaining = _add_message_cache_control(remaining)
-    kwargs = _convert_tools(kwargs)
+    kwargs = _convert_tools(
+        kwargs,
+        enable_cache=(n_sys_breakpoints < _MAX_NON_MESSAGE_BREAKPOINTS),
+    )
     stream = kwargs.pop("stream", False)
 
     if "max_tokens" not in kwargs:

--- a/tests/test_anthropic_cache.py
+++ b/tests/test_anthropic_cache.py
@@ -108,8 +108,10 @@ def test_manual_list_without_markers_gets_trailing_breakpoint() -> None:
         },
     ])
     assert n == 1
-    assert "cache_control" not in system[0]
-    assert system[1]["cache_control"] == EPHEMERAL
+    assert system == [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "last", "cache_control": EPHEMERAL},
+    ]
 
 
 # --- tool breakpoint budget ---

--- a/tests/test_anthropic_cache.py
+++ b/tests/test_anthropic_cache.py
@@ -1,0 +1,146 @@
+"""Tests for Anthropic system/tool cache-breakpoint placement.
+
+Covers the caller-controlled breakpoint feature and guards the historical
+default behaviour (single concatenated system block) against regression.
+"""
+
+import anthropic
+
+from llmax.external_clients.anthropic import (
+    _MAX_NON_MESSAGE_BREAKPOINTS,
+    _convert_tools,
+    _extract_system,
+)
+
+EPHEMERAL = {"type": "ephemeral"}
+
+
+def _tools_kwargs() -> dict:
+    """Two OpenAI-style function tools, as a fresh kwargs dict."""
+    return {
+        "tools": [
+            {"type": "function", "function": {"name": "a", "parameters": {}}},
+            {"type": "function", "function": {"name": "b", "parameters": {}}},
+        ],
+    }
+
+
+# --- default mode (string system): must stay byte-identical to historical ---
+
+
+def test_default_single_string_system() -> None:
+    """A single string system message → one block with a trailing breakpoint."""
+    system, remaining, n = _extract_system([
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "hi"},
+    ])
+    assert n == 1
+    assert system == [
+        {"type": "text", "text": "You are helpful.", "cache_control": EPHEMERAL},
+    ]
+    assert remaining == [{"role": "user", "content": "hi"}]
+
+
+def test_default_multiple_string_systems_are_joined() -> None:
+    """Several string system messages are concatenated into one block."""
+    system, _remaining, n = _extract_system([
+        {"role": "system", "content": "A"},
+        {"role": "system", "content": "B"},
+        {"role": "user", "content": "hi"},
+    ])
+    assert n == 1
+    assert system == [{"type": "text", "text": "A B", "cache_control": EPHEMERAL}]
+
+
+def test_no_system_returns_not_given() -> None:
+    """No system message → NOT_GIVEN and zero breakpoints."""
+    system, remaining, n = _extract_system([{"role": "user", "content": "hi"}])
+    assert system is anthropic.NOT_GIVEN
+    assert n == 0
+    assert remaining == [{"role": "user", "content": "hi"}]
+
+
+# --- manual mode (caller-supplied blocks with cache_control) ---
+
+
+def test_manual_two_breakpoints_preserved() -> None:
+    """List content with two markers is preserved verbatim (two breakpoints)."""
+    system, _remaining, n = _extract_system([
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "cohort", "cache_control": EPHEMERAL},
+                {"type": "text", "text": "per-user", "cache_control": EPHEMERAL},
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ])
+    assert n == _MAX_NON_MESSAGE_BREAKPOINTS
+    assert system == [
+        {"type": "text", "text": "cohort", "cache_control": EPHEMERAL},
+        {"type": "text", "text": "per-user", "cache_control": EPHEMERAL},
+    ]
+
+
+def test_manual_single_breakpoint_preserved() -> None:
+    """One marked block + one unmarked block → a single breakpoint."""
+    _system, _remaining, n = _extract_system([
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "cohort", "cache_control": EPHEMERAL},
+                {"type": "text", "text": "per-user"},
+            ],
+        },
+    ])
+    assert n == 1
+
+
+def test_manual_list_without_markers_gets_trailing_breakpoint() -> None:
+    """List content with no markers falls back to one trailing breakpoint."""
+    system, _remaining, n = _extract_system([
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "last"},
+            ],
+        },
+    ])
+    assert n == 1
+    assert "cache_control" not in system[0]
+    assert system[1]["cache_control"] == EPHEMERAL
+
+
+# --- tool breakpoint budget ---
+
+
+def test_tools_cache_enabled_by_default() -> None:
+    """By default the last tool carries a cache_control breakpoint."""
+    out = _convert_tools(_tools_kwargs())
+    assert out["tools"][-1]["cache_control"] == EPHEMERAL
+
+
+def test_tools_cache_dropped_when_disabled() -> None:
+    """enable_cache=False leaves the tools array without a breakpoint."""
+    out = _convert_tools(_tools_kwargs(), enable_cache=False)
+    assert "cache_control" not in out["tools"][-1]
+
+
+def test_budget_two_system_breakpoints_drops_tool_breakpoint() -> None:
+    """Mirrors anthropic_create: two system breakpoints drop the tools one."""
+    _system, _remaining, n = _extract_system([
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "cohort", "cache_control": EPHEMERAL},
+                {"type": "text", "text": "per-user", "cache_control": EPHEMERAL},
+            ],
+        },
+    ])
+    out = _convert_tools(
+        _tools_kwargs(),
+        enable_cache=(n < _MAX_NON_MESSAGE_BREAKPOINTS),
+    )
+    # 2 system + 2 messages (max) + 0 tools = within the 4-breakpoint budget.
+    assert "cache_control" not in out["tools"][-1]

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "delos-llmax"
-version = "1.42.0"
+version = "1.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
_extract_system now preserves caller-supplied system content blocks and the cache_control markers on them instead of always flattening everything into a single block. A plain-string system keeps the exact historical behaviour (one concatenated block with a single trailing breakpoint).

_convert_tools gains enable_cache; anthropic_create/acreate drop the tools breakpoint when the system already uses 2 breakpoints, so the request stays within Anthropic's 4-breakpoint budget (2 system + 2 messages). The first system breakpoint sits after the tools array and already caches it.

system kwargs widened to str | list[dict] | None. Adds tests/test_anthropic_cache.py including a default-mode regression guard.