### PR TITLE
feat: add glm-5.2 (OpenRouter) model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "delos-llmax"
 
 
-version = "1.47.0"
+version = "1.48.0"
 description = "Interface to handle multiple LLMs and AI tools."
 authors = [
     { name = "Delos Intelligence", email = "maximiliendedinechin@delosintelligence.fr" },

--- a/src/llmax/models/models.py
+++ b/src/llmax/models/models.py
@@ -60,6 +60,7 @@ OpenRouterModel = Literal[
     "deepseek-v4-flash",
     "glm-4.7",
     "glm-5.1",
+    "glm-5.2",
     "llama-4-maverick",
     "qwen3.6-plus",
     "kimi-k2.5",

--- a/src/llmax/usage/prices.py
+++ b/src/llmax/usage/prices.py
@@ -57,6 +57,7 @@ PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "deepseek-v4-flash": {"openrouter": 0.14},
     "glm-4.7": {"openrouter": 0.38},
     "glm-5.1": {"openrouter": 1.05},
+    "glm-5.2": {"openrouter": 1.40},
     "llama-4-maverick": {"openrouter": 0.15},
     "qwen3.6-plus": {"openrouter": 0.325},
     "kimi-k2.5": {"openrouter": 0.44},
@@ -86,6 +87,7 @@ CACHED_PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "claude-4.8-opus": 0.50,
     "deepseek-v4-pro": {"openrouter": 0.10875},  # input * 0.25
     "deepseek-v4-flash": {"openrouter": 0.035},  # input * 0.25
+    "glm-5.2": {"openrouter": 0.26},
 }
 
 COMPLETION_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
@@ -136,6 +138,7 @@ COMPLETION_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "deepseek-v4-flash": {"openrouter": 0.28},
     "glm-4.7": {"openrouter": 1.74},
     "glm-5.1": {"openrouter": 3.50},
+    "glm-5.2": {"openrouter": 4.40},
     "llama-4-maverick": {"openrouter": 0.60},
     "qwen3.6-plus": {"openrouter": 1.95},
     "kimi-k2.5": {"openrouter": 2.00},


### PR DESCRIPTION
Add glm-5.2 to OpenRouterModel literal and prompt/completion price tables, bump version to 1.48.0.

NOTE: input/output prices are placeholders (copied from glm-5.1) pending confirmation of the real OpenRouter glm-5.2 pricing (see TODO comments).