### PR TITLE
feat: add claude-5-sonnet (Anthropic on AWS Bedrock)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "delos-llmax"
 
 
-version = "1.48.0"
+version = "1.49.0"
 description = "Interface to handle multiple LLMs and AI tools."
 authors = [
     { name = "Delos Intelligence", email = "maximiliendedinechin@delosintelligence.fr" },

--- a/src/llmax/models/models.py
+++ b/src/llmax/models/models.py
@@ -53,6 +53,7 @@ AnthropicModel = Literal[
     "claude-4.6-sonnet",
     "claude-4.7-opus",
     "claude-4.8-opus",
+    "claude-5-sonnet",
 ]
 
 OpenRouterModel = Literal[

--- a/src/llmax/usage/prices.py
+++ b/src/llmax/usage/prices.py
@@ -18,6 +18,7 @@ PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "claude-4.6-opus": 5.0,
     "claude-4.7-opus": 5.0,
     "claude-4.8-opus": 5.0,
+    "claude-5-sonnet": 3.0,
     "llama-3-70b-instruct": 3.78,  # To be checked
     "llama-4-scout-17b-16e-instruct": 0.275,  # To be checked
     "llama-4-maverick-17b-128e-instruct-fp8": 0.275,  # To be checked
@@ -85,6 +86,7 @@ CACHED_PROMPT_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "claude-4.6-opus": 0.50,
     "claude-4.7-opus": 0.50,
     "claude-4.8-opus": 0.50,
+    "claude-5-sonnet": 0.30,
     "deepseek-v4-pro": {"openrouter": 0.10875},  # input * 0.25
     "deepseek-v4-flash": {"openrouter": 0.035},  # input * 0.25
     "glm-5.2": {"openrouter": 0.26},
@@ -103,6 +105,7 @@ COMPLETION_PRICES_PER_1M: dict[Model, float | dict[Provider, float]] = {
     "claude-4.6-opus": 25.0,
     "claude-4.7-opus": 25.0,
     "claude-4.8-opus": 25.0,
+    "claude-5-sonnet": 15.0,
     "llama-3-70b-instruct": 11.34,
     "llama-4-scout-17b-16e-instruct": 1.1,  # To be checked
     "llama-4-maverick-17b-128e-instruct-fp8": 1.1,  # To be checked

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "delos-llmax"
-version = "1.48.0"
+version = "1.49.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -504,7 +504,7 @@ dev = [
     { name = "isort", specifier = ">=5.13.2" },
     { name = "mypy", specifier = ">=1.11.1" },
     { name = "pydub-stubs", specifier = ">=0.25.1.1" },
-    { name = "pytest", specifier = ">=7,<9" },
+    { name = "pytest", specifier = ">=7,<10" },
     { name = "pytest-cov", specifier = ">=3,<6" },
     { name = "ruff", specifier = ">=0.6.1" },
     { name = "ty", specifier = ">=0.0.18" },


### PR DESCRIPTION
Add claude-5-sonnet to the AnthropicModel literal and the prompt/cached/completion price tables (input $3.00, output $15.00, cache read $0.30 per 1M), bump version to 1.49.0.

Bedrock routing already exists: deployments use provider aws-bedrock with deployment_name anthropic.claude-sonnet-5.